### PR TITLE
Use full URL syntax for github deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,16 @@
       "integrity": "sha512-N9OVsMBspboNvYaLAQnLEhb2eQ96lavogMR5LoH5k8nb1PvBZHSBFhzhsq2LNzGTBBOtBviOc1GiSu+wlM/pGw==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -2859,8 +2869,8 @@
       "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.2.0",
@@ -2897,8 +2907,8 @@
           "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
           "dev": true,
           "requires": {
-            "is-text-path": "1.0.1",
             "JSONStream": "1.3.1",
+            "is-text-path": "1.0.1",
             "lodash": "4.17.4",
             "meow": "3.7.0",
             "split2": "2.2.0",
@@ -5794,14 +5804,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5810,6 +5812,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -8155,16 +8165,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -12039,7 +12039,7 @@
       }
     },
     "react-dimensions": {
-      "version": "github:AlesJiranek/react-dimensions#9cd7cd8c7086ef61d0f4e31bb0fa84ac5ff03cbb",
+      "version": "git://github.com/AlesJiranek/react-dimensions.git#9cd7cd8c7086ef61d0f4e31bb0fa84ac5ff03cbb",
       "dev": true,
       "requires": {
         "element-resize-event": "2.0.9",
@@ -12435,7 +12435,7 @@
       }
     },
     "reactstrap": {
-      "version": "github:jameswomack/reactstrap#fd9a7df74b7dde095ec9066d49980cddbc7ba74c",
+      "version": "git://github.com/jameswomack/reactstrap.git#fd9a7df74b7dde095ec9066d49980cddbc7ba74c",
       "dev": true,
       "requires": {
         "classnames": "2.2.5",
@@ -12972,7 +12972,7 @@
       }
     },
     "roughjs": {
-      "version": "github:emeeks/rough#cb575d9304a5d5de33b0ef307b11894d55221b5b",
+      "version": "git://github.com/emeeks/rough.git#337522cf2ccea6218c7b2b8366e85c7d9538fe52",
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -13518,15 +13518,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -13572,6 +13563,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.9.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "material-design-icons-svg": "1.1.2",
     "nyc": "5.5.0",
     "react": "^16.0.0",
-    "react-dimensions": "github:AlesJiranek/react-dimensions",
+    "react-dimensions": "git://github.com/AlesJiranek/react-dimensions",
     "react-dom": "^16.0.0",
     "react-element-to-jsx-string": "^12.0.0",
     "react-prism": "4.3.1",
@@ -61,7 +61,7 @@
     "react-scripts": "1.0.13",
     "react-tap-event-plugin": "3.0.2",
     "react-test-renderer": "16.0.0",
-    "reactstrap": "github:jameswomack/reactstrap#react-popper_react-dom-16",
+    "reactstrap": "git://github.com/jameswomack/reactstrap#react-popper_react-dom-16",
     "tap-difflet": "0.4.0",
     "tap-notify": "1.0.0",
     "tape": "4.4.0"
@@ -77,7 +77,7 @@
     "d3-shape": "^1.0.3",
     "d3-transition": "^1.0.3",
     "prop-types": "^15.6.0",
-    "roughjs": "github:emeeks/rough"
+    "roughjs": "git://github.com/emeeks/rough"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
Some package managers (like yarn) don't deal well
with `github:` style dependency locations. This
changes those in semiotic-mark to the equivalent
full-URL style.